### PR TITLE
Update Pointer Position when a New Color is Selected

### DIFF
--- a/packages/color-picker/src/components/common/Saturation.tsx
+++ b/packages/color-picker/src/components/common/Saturation.tsx
@@ -29,10 +29,14 @@ export default function Saturation({
   });
 
   useEffect(() => {
+    pointerPositionSet({
+      saturation: hsv.s * 100,
+      brightness: hsv.v * 100
+    });
     return () => {
       unbindEventListeners();
     };
-  }, []);
+  }, [hsv]);
 
   function handleChange(
     event: React.MouseEvent | React.TouchEvent | MouseEvent


### PR DESCRIPTION
Fix the pointer (thumb) position to follow the color that the user picks ie. from a color swatch.

https://github.com/hipstersmoothie/color-picker/assets/3172104/a6d4e3f4-5e95-43ff-be95-8e2a5a8c1d6b

See behavior before: The pointer remained in the same position after selecting a color from the swatches, which isn't accurate and creates some confusion when the user clicks on the pointer box itself
https://github.com/hipstersmoothie/color-picker/assets/3172104/4ca8404e-7cc8-45a9-aac1-dcc6dfc96821


